### PR TITLE
Enhance arc_dsl.py with to_dict methods, class rename, and conditiona…

### DIFF
--- a/src/ur_project/core/arc_dsl.py
+++ b/src/ur_project/core/arc_dsl.py
@@ -1,9 +1,30 @@
 # src/ur_project/core/arc_dsl.py
 from typing import List, Tuple, Union, Optional, Any, Dict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict, is_dataclass
+from abc import ABC, abstractmethod
 
 from ur_project.data_processing.arc_types import ARCPixel, ARCGrid
 # Potential future import: from .knowledge_base import SymbolicEntity # If DSL operates on symbolic entities
+
+# --- Helper function for to_dict ---
+
+def _convert_value(value: Any) -> Any:
+    """Recursively converts values for to_dict methods."""
+    if isinstance(value, ARCPixel):
+        return value.value
+    elif isinstance(value, list):
+        return [_convert_value(item) for item in value]
+    elif isinstance(value, dict):
+        return {k: _convert_value(v) for k, v in value.items()}
+    elif hasattr(value, 'to_dict') and callable(value.to_dict):
+        return value.to_dict()
+    # Check for dataclasses that are not our specific DSL objects but might contain them
+    # This handles cases like ARCGrid (List[List[ARCPixel]]) correctly
+    # if it wasn't handled by the isinstance(value, list) above.
+    # However, ARCGrid is List[List[ARCPixel]] so the list comprehension handles it.
+    # Generic dataclasses not part of DSL but containing DSL parts would need explicit handling
+    # if not covered by the above. For now, this seems sufficient.
+    return value
 
 # --- DSL Core Concepts ---
 
@@ -19,6 +40,17 @@ class DSLObjectSelector:
     criteria: Dict[str, Any]
     select_all_matching: bool = False # If true, operation applies to all matching, else typically the first or a specific one.
 
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        # Specifically handle the 'criteria' dict as its values might be ARCPixel or other DSL objects
+        if 'criteria' in data and isinstance(data['criteria'], dict):
+            data['criteria'] = {k: _convert_value(v) for k, v in data['criteria'].items()}
+        # Apply conversion to other fields as a general step, though criteria is the main complex one here
+        for key, value in data.items():
+            if key != 'criteria': # Already handled
+                 data[key] = _convert_value(value)
+        return data
+
 @dataclass
 class DSLPosition:
     """Represents a position, absolute or relative."""
@@ -26,27 +58,49 @@ class DSLPosition:
     col: int
     is_relative: bool = False # If true, (row, col) are deltas from a reference point
 
+    def to_dict(self) -> Dict[str, Any]:
+        # Simple fields, asdict is enough, _convert_value handles potential ARCPixel if they were part of this
+        return asdict(self) # No complex types like ARCPixel or nested DSL objects expected here directly
+                            # but if they were, _convert_value would be needed in a loop like DSLObjectSelector
+                            # For now, assuming row/col/is_relative are basic types.
+                            # If DSLPosition could hold an ARCPixel for e.g. a coordinate, then conversion would be needed.
+                            # Let's stick to the provided example and keep it simple.
+                            # data = asdict(self)
+                            # for key, value in data.items(): data[key] = _convert_value(value)
+                            # return data
+                            # Given current structure, direct asdict is fine.
+        return asdict(self)
+
 @dataclass
 class DSLColor:
     """Represents a color, which could be an ARCPixel or a special keyword (e.g., 'background_color')."""
     value: Union[ARCPixel, str]
 
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data['value'] = _convert_value(self.value)
+        return data
+
 # --- DSL Operations (Version 1 - Basic) ---
 
 @dataclass
-class DSLOperation(ABC): # Python 3.9+ for ABC from dataclasses
+class BaseOperation(ABC): # Python 3.9+ for ABC from dataclasses
     """Abstract base class for all DSL operations."""
-    pass
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        for key, value in data.items():
+            data[key] = _convert_value(value)
+        return data
 
 @dataclass
-class ChangeColorOp(DSLOperation):
+class ChangeColorOp(BaseOperation):
     """Changes the color of selected object(s) or area."""
     selector: DSLObjectSelector # Could also be a region selector in future
     new_color: DSLColor
     operation_name: str = field(default="ChangeColor", init=False)
 
 @dataclass
-class MoveOp(DSLOperation):
+class MoveOp(BaseOperation):
     """Moves selected object(s)."""
     selector: DSLObjectSelector
     destination: DSLPosition # Could be absolute or relative to object's current position
@@ -54,7 +108,7 @@ class MoveOp(DSLOperation):
     operation_name: str = field(default="Move", init=False)
 
 @dataclass
-class CopyObjectOp(DSLOperation):
+class CopyObjectOp(BaseOperation):
     """Copies selected object(s) to a new position."""
     selector: DSLObjectSelector
     destination: DSLPosition # Top-left of where the copy should be placed
@@ -62,7 +116,7 @@ class CopyObjectOp(DSLOperation):
     operation_name: str = field(default="CopyObject", init=False)
 
 @dataclass
-class CreateObjectOp(DSLOperation):
+class CreateObjectOp(BaseOperation):
     """Creates a new object (e.g., draws a shape)."""
     shape_data: ARCGrid # The grid representing the shape to draw
     destination: DSLPosition # Top-left position to draw the shape
@@ -70,7 +124,7 @@ class CreateObjectOp(DSLOperation):
     operation_name: str = field(default="CreateObject", init=False)
 
 @dataclass
-class FillRectangleOp(DSLOperation):
+class FillRectangleOp(BaseOperation):
     """Fills a rectangular area with a color."""
     top_left: DSLPosition
     bottom_right: DSLPosition
@@ -78,23 +132,87 @@ class FillRectangleOp(DSLOperation):
     operation_name: str = field(default="FillRectangle", init=False)
 
 @dataclass
-class DeleteObjectOp(DSLOperation):
+class DeleteObjectOp(BaseOperation):
     """Deletes selected object(s) (e.g., changes their pixels to background color)."""
     selector: DSLObjectSelector
     operation_name: str = field(default="DeleteObject", init=False)
+
+# --- Conditional Logic DSL Components ---
+
+@dataclass
+class Condition(ABC):
+    """Abstract base class for different types of conditions."""
+    condition_type: str = field(init=False)
+
+    @abstractmethod
+    def to_dict(self) -> Dict[str, Any]:
+        """Converts the condition to a dictionary."""
+        pass
+
+@dataclass
+class PixelMatchesCondition(Condition):
+    """Condition that checks if a pixel at a position matches a specific color."""
+    position: DSLPosition
+    expected_color: DSLColor
+    condition_type: str = field(default="PixelMatchesCondition", init=False)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data['position'] = _convert_value(self.position) # Uses helper for consistency
+        data['expected_color'] = _convert_value(self.expected_color) # Uses helper for consistency
+        return data
+
+@dataclass
+class ObjectExistsCondition(Condition):
+    """Condition that checks if an object matching certain criteria exists."""
+    selector: DSLObjectSelector
+    condition_type: str = field(default="ObjectExistsCondition", init=False)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data['selector'] = _convert_value(self.selector) # Uses helper for consistency
+        return data
+
+@dataclass
+class ConditionalBranch:
+    """Represents a branch of execution: a condition and a program to run if true."""
+    condition: Condition # Union of specific condition types can be enforced by type checkers if needed
+    program: 'DSLProgram' # Forward reference for DSLProgram
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "condition": _convert_value(self.condition),
+            "program": _convert_value(self.program)
+        }
+
+@dataclass
+class IfElseOp(BaseOperation):
+    """Operation for conditional logic (if-else)."""
+    main_branch: ConditionalBranch
+    else_branch: Optional['DSLProgram'] = None # Optional 'else' program
+    operation_name: str = field(default="IfElse", init=False)
+
+    # to_dict is inherited from BaseOperation and should work correctly
+    # as long as ConditionalBranch and DSLProgram have proper to_dict methods
+    # and _convert_value handles them, which it does.
 
 # --- DSL Program ---
 
 @dataclass
 class DSLProgram:
     """Represents a sequence of DSL operations to solve an ARC task."""
-    operations: List[DSLOperation]
+    operations: List[BaseOperation]  # IfElseOp is a BaseOperation, so this is fine.
     # Future: Could include variables, control flow (loops, conditionals)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "operations": [_convert_value(op) for op in self.operations]
+            # If DSLProgram had other fields needing conversion, handle them here
+        }
 
 # --- Example Usage (Illustrative) ---
 if __name__ == '__main__':
-    from abc import ABC # Add this import for the example to run standalone
-
+    # (Previous examples from DSLProgram) ...
     # Example: Select all red objects
     selector_red_objects = DSLObjectSelector(criteria={"color": ARCPixel(2)}, select_all_matching=True)
     
@@ -126,3 +244,69 @@ if __name__ == '__main__':
     print(f"\nProgram has {len(program.operations)} operations.")
     for i, op in enumerate(program.operations):
         print(f"  Step {i}: {op.operation_name}") 
+
+    # Example for Conditional Logic
+    print("\n--- Conditional Logic Example ---")
+
+    # 1. Define a condition: Check if pixel (0,0) is black (ARCPixel(0))
+    cond_pixel_is_black = PixelMatchesCondition(
+        position=DSLPosition(row=0, col=0),
+        expected_color=DSLColor(value=ARCPixel(0))
+    )
+    print(f"Condition defined: {cond_pixel_is_black.to_dict()}")
+
+    # 2. Define a sub-program to run if condition is true
+    #    (e.g., fill rectangle (1,1)-(2,2) with blue (ARCPixel(1)))
+    program_if_true = DSLProgram(operations=[
+        FillRectangleOp(
+            top_left=DSLPosition(1,1),
+            bottom_right=DSLPosition(2,2),
+            color=DSLColor(ARCPixel(1))
+        )
+    ])
+    print(f"Sub-program if true: {program_if_true.to_dict()}")
+
+    # 3. Create a conditional branch
+    main_branch = ConditionalBranch(
+        condition=cond_pixel_is_black,
+        program=program_if_true
+    )
+    print(f"Main branch defined: {main_branch.to_dict()}")
+
+    # 4. (Optional) Define an 'else' program
+    #    (e.g., delete object with color red (ARCPixel(2)))
+    program_if_false = DSLProgram(operations=[
+        DeleteObjectOp(selector=DSLObjectSelector(criteria={"color": ARCPixel(2)}))
+    ])
+    print(f"Sub-program if false (else branch): {program_if_false.to_dict()}")
+
+    # 5. Create the IfElse Operation
+    if_else_op = IfElseOp(
+        main_branch=main_branch,
+        else_branch=program_if_false
+    )
+    print(f"IfElseOp defined: {if_else_op.to_dict()}")
+    
+    # Add it to the main program
+    program.operations.append(if_else_op)
+
+    print(f"\nUpdated program has {len(program.operations)} operations.")
+    for i, op in enumerate(program.operations):
+        print(f"  Step {i}: {op.operation_name}") 
+        if op.operation_name == "IfElse":
+            print(f"    If condition: {op.main_branch.condition.condition_type}") # type: ignore
+            print(f"    Else branch exists: {op.else_branch is not None}") # type: ignore
+
+    # Example for ObjectExistsCondition
+    cond_object_exists = ObjectExistsCondition(
+        selector=DSLObjectSelector(criteria={"color": ARCPixel(3)}, select_all_matching=False)
+    )
+    print(f"ObjectExistsCondition defined: {cond_object_exists.to_dict()}")
+
+    if_object_exists_op = IfElseOp(
+        main_branch=ConditionalBranch(
+            condition=cond_object_exists,
+            program=DSLProgram(operations=[CreateObjectOp(ARCGrid([[ARCPixel(8)]]), DSLPosition(5,5))])
+        )
+    )
+    print(f"IfElseOp with ObjectExistsCondition: {if_object_exists_op.to_dict()}")

--- a/src/ur_project/core/test_arc_dsl.py
+++ b/src/ur_project/core/test_arc_dsl.py
@@ -1,0 +1,278 @@
+# src/ur_project/core/test_arc_dsl.py
+import unittest
+# Import the module itself to check its attributes for renaming test
+import ur_project.core.arc_dsl as arc_dsl_module
+from ur_project.core.arc_dsl import (
+    BaseOperation, DSLObjectSelector, DSLPosition, DSLColor,
+    ChangeColorOp, MoveOp, CopyObjectOp, CreateObjectOp, FillRectangleOp, DeleteObjectOp,
+    DSLProgram,
+    Condition, PixelMatchesCondition, ObjectExistsCondition, ConditionalBranch, IfElseOp
+)
+# Make sure to import ARCPixel if you need to create instances for testing
+from ur_project.data_processing.arc_types import ARCPixel, ARCGrid 
+
+# If ur_project.data_processing.arc_types is not directly importable,
+# adjust the import path as needed. Assume it's available for now.
+
+class TestArcDslRenaming(unittest.TestCase):
+    def test_base_operation_exists(self):
+        self.assertTrue(hasattr(arc_dsl_module, 'BaseOperation'))
+        self.assertFalse(hasattr(arc_dsl_module, 'DSLOperation'))
+
+    def test_subclass_inheritance(self):
+        self.assertTrue(issubclass(ChangeColorOp, BaseOperation))
+        self.assertTrue(issubclass(MoveOp, BaseOperation))
+        self.assertTrue(issubclass(CopyObjectOp, BaseOperation))
+        self.assertTrue(issubclass(CreateObjectOp, BaseOperation))
+        self.assertTrue(issubclass(FillRectangleOp, BaseOperation))
+        self.assertTrue(issubclass(DeleteObjectOp, BaseOperation))
+        self.assertTrue(issubclass(IfElseOp, BaseOperation)) # Also an operation
+
+class TestArcDslToDict(unittest.TestCase):
+    def test_dsl_color_to_dict(self):
+        color = DSLColor(value=ARCPixel(5))
+        expected_dict = {"value": 5}
+        self.assertEqual(color.to_dict(), expected_dict)
+
+        color_str = DSLColor(value="background")
+        expected_dict_str = {"value": "background"}
+        self.assertEqual(color_str.to_dict(), expected_dict_str)
+
+    def test_dsl_position_to_dict(self):
+        pos = DSLPosition(row=1, col=2, is_relative=True)
+        expected_dict = {"row": 1, "col": 2, "is_relative": True}
+        self.assertEqual(pos.to_dict(), expected_dict)
+
+    def test_dsl_object_selector_to_dict(self):
+        selector = DSLObjectSelector(criteria={"color": ARCPixel(3), "size": 5}, select_all_matching=True)
+        expected_dict = {"criteria": {"color": 3, "size": 5}, "select_all_matching": True}
+        self.assertEqual(selector.to_dict(), expected_dict)
+        
+        selector_nested = DSLObjectSelector(criteria={"anchor_pixel": DSLPosition(0,0)})
+        expected_dict_nested = {"criteria": {"anchor_pixel": {"row":0, "col":0, "is_relative": False}}, "select_all_matching": False}
+        self.assertEqual(selector_nested.to_dict(), expected_dict_nested)
+
+    def test_change_color_op_to_dict(self):
+        selector = DSLObjectSelector(criteria={"color": ARCPixel(2)})
+        new_color = DSLColor(value=ARCPixel(1))
+        op = ChangeColorOp(selector=selector, new_color=new_color)
+        expected_dict = {
+            "operation_name": "ChangeColor",
+            "selector": {"criteria": {"color": 2}, "select_all_matching": False},
+            "new_color": {"value": 1}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+
+    def test_move_op_to_dict(self):
+        selector = DSLObjectSelector(criteria={"id": "obj1"})
+        destination = DSLPosition(row=5, col=5, is_relative=False)
+        op = MoveOp(selector=selector, destination=destination)
+        expected_dict = {
+            "operation_name": "Move",
+            "selector": {"criteria": {"id": "obj1"}, "select_all_matching": False},
+            "destination": {"row": 5, "col": 5, "is_relative": False}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+
+    def test_copy_object_op_to_dict(self):
+        selector = DSLObjectSelector(criteria={"color": ARCPixel(7)})
+        destination = DSLPosition(row=2, col=3, is_relative=True)
+        op = CopyObjectOp(selector=selector, destination=destination)
+        expected_dict = {
+            "operation_name": "CopyObject",
+            "selector": {"criteria": {"color": 7}, "select_all_matching": False},
+            "destination": {"row": 2, "col": 3, "is_relative": True}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+
+    def test_create_object_op_to_dict(self):
+        shape: ARCGrid = [[ARCPixel(1), ARCPixel(0)], [ARCPixel(1), ARCPixel(1)]]
+        dest = DSLPosition(1,1)
+        color = DSLColor(ARCPixel(5))
+        op = CreateObjectOp(shape_data=shape, destination=dest, color=color)
+        expected_dict = {
+            "operation_name": "CreateObject",
+            "shape_data": [[1,0], [1,1]],
+            "destination": {"row":1, "col":1, "is_relative":False},
+            "color": {"value": 5}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+        
+        # Test with no explicit color (should be None)
+        op_no_color = CreateObjectOp(shape_data=shape, destination=dest)
+        expected_dict_no_color = {
+            "operation_name": "CreateObject",
+            "shape_data": [[1,0], [1,1]],
+            "destination": {"row":1, "col":1, "is_relative":False},
+            "color": None
+        }
+        self.assertEqual(op_no_color.to_dict(), expected_dict_no_color)
+
+
+    def test_fill_rectangle_op_to_dict(self):
+        top_left = DSLPosition(row=0, col=0)
+        bottom_right = DSLPosition(row=4, col=4)
+        color = DSLColor(value=ARCPixel(8))
+        op = FillRectangleOp(top_left=top_left, bottom_right=bottom_right, color=color)
+        expected_dict = {
+            "operation_name": "FillRectangle",
+            "top_left": {"row": 0, "col": 0, "is_relative": False},
+            "bottom_right": {"row": 4, "col": 4, "is_relative": False},
+            "color": {"value": 8}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+
+    def test_delete_object_op_to_dict(self):
+        selector = DSLObjectSelector(criteria={"size": 10, "shape": "square"})
+        op = DeleteObjectOp(selector=selector)
+        expected_dict = {
+            "operation_name": "DeleteObject",
+            "selector": {"criteria": {"size": 10, "shape": "square"}, "select_all_matching": False}
+        }
+        self.assertEqual(op.to_dict(), expected_dict)
+
+    def test_dsl_program_to_dict(self):
+        op1 = ChangeColorOp(DSLObjectSelector(criteria={"id":"obj1"}), DSLColor(ARCPixel(2)))
+        op2 = MoveOp(DSLObjectSelector(criteria={"id":"obj2"}), DSLPosition(1,1,True))
+        program = DSLProgram(operations=[op1, op2])
+        expected_dict = {
+            "operations": [
+                {
+                    "operation_name": "ChangeColor",
+                    "selector": {"criteria": {"id":"obj1"}, "select_all_matching": False},
+                    "new_color": {"value": 2}
+                },
+                {
+                    "operation_name": "Move",
+                    "selector": {"criteria": {"id":"obj2"}, "select_all_matching": False},
+                    "destination": {"row":1, "col":1, "is_relative":True}
+                }
+            ]
+        }
+        self.assertEqual(program.to_dict(), expected_dict)
+
+class TestConditionalDsl(unittest.TestCase):
+    def test_conditional_class_structure(self):
+        self.assertTrue(issubclass(IfElseOp, BaseOperation))
+        self.assertTrue(issubclass(PixelMatchesCondition, Condition))
+        self.assertTrue(issubclass(ObjectExistsCondition, Condition))
+
+    def test_pixel_matches_condition_to_dict(self):
+        cond = PixelMatchesCondition(
+            position=DSLPosition(1, 1),
+            expected_color=DSLColor(ARCPixel(3))
+        )
+        expected = {
+            "condition_type": "PixelMatchesCondition",
+            "position": {"row": 1, "col": 1, "is_relative": False},
+            "expected_color": {"value": 3}
+        }
+        self.assertEqual(cond.to_dict(), expected)
+
+    def test_object_exists_condition_to_dict(self):
+        cond = ObjectExistsCondition(
+            selector=DSLObjectSelector(criteria={"color": ARCPixel(4)})
+        )
+        expected = {
+            "condition_type": "ObjectExistsCondition",
+            "selector": {"criteria": {"color": 4}, "select_all_matching": False}
+        }
+        self.assertEqual(cond.to_dict(), expected)
+
+    def test_conditional_branch_to_dict(self):
+        cond = ObjectExistsCondition(selector=DSLObjectSelector(criteria={"id": "A"}))
+        prog_ops = [ChangeColorOp(DSLObjectSelector(criteria={"id":"A"}), DSLColor(ARCPixel(1)))]
+        prog = DSLProgram(operations=prog_ops)
+        branch = ConditionalBranch(condition=cond, program=prog)
+        
+        expected = {
+            "condition": {
+                "condition_type": "ObjectExistsCondition",
+                "selector": {"criteria": {"id": "A"}, "select_all_matching": False}
+            },
+            "program": {
+                "operations": [{
+                    "operation_name": "ChangeColor",
+                    "selector": {"criteria": {"id":"A"}, "select_all_matching": False},
+                    "new_color": {"value": 1}
+                }]
+            }
+        }
+        self.assertEqual(branch.to_dict(), expected)
+
+    def test_if_else_op_to_dict(self):
+        # Main branch
+        cond_main = PixelMatchesCondition(DSLPosition(0,0), DSLColor(ARCPixel(1)))
+        prog_main_ops = [DeleteObjectOp(DSLObjectSelector(criteria={"id":"target"}))]
+        prog_main = DSLProgram(operations=prog_main_ops)
+        main_branch = ConditionalBranch(condition=cond_main, program=prog_main)
+
+        # Else branch
+        prog_else_ops = [CreateObjectOp(ARCGrid([[ARCPixel(2)]]), DSLPosition(1,1), DSLColor(ARCPixel(2)))]
+        prog_else = DSLProgram(operations=prog_else_ops)
+
+        op_if_else = IfElseOp(main_branch=main_branch, else_branch=prog_else)
+        
+        expected = {
+            "operation_name": "IfElse",
+            "main_branch": {
+                "condition": {
+                    "condition_type": "PixelMatchesCondition",
+                    "position": {"row":0, "col":0, "is_relative":False},
+                    "expected_color": {"value":1}
+                },
+                "program": {
+                    "operations": [{
+                        "operation_name": "DeleteObject",
+                        "selector": {"criteria": {"id":"target"}, "select_all_matching":False}
+                    }]
+                }
+            },
+            "else_branch": {
+                "operations": [{
+                    "operation_name": "CreateObject",
+                    "shape_data": [[2]],
+                    "destination": {"row":1, "col":1, "is_relative":False},
+                    "color": {"value":2}
+                }]
+            }
+        }
+        self.assertEqual(op_if_else.to_dict(), expected)
+
+    def test_if_else_op_to_dict_no_else(self):
+        cond_main = PixelMatchesCondition(DSLPosition(0,0), DSLColor(ARCPixel(1)))
+        prog_main_ops = [DeleteObjectOp(DSLObjectSelector(criteria={"id":"target"}))]
+        prog_main = DSLProgram(operations=prog_main_ops)
+        main_branch = ConditionalBranch(condition=cond_main, program=prog_main)
+        op_if_only = IfElseOp(main_branch=main_branch) # No else branch
+
+        expected = {
+            "operation_name": "IfElse",
+            "main_branch": {
+                "condition": {
+                    "condition_type": "PixelMatchesCondition",
+                    "position": {"row":0, "col":0, "is_relative":False},
+                    "expected_color": {"value":1}
+                },
+                "program": {
+                    "operations": [{
+                        "operation_name": "DeleteObject",
+                        "selector": {"criteria": {"id":"target"}, "select_all_matching":False}
+                    }]
+                }
+            },
+            "else_branch": None
+        }
+        self.assertEqual(op_if_only.to_dict(), expected)
+
+
+if __name__ == '__main__':
+    # This is so you can run the test script directly
+    # You might need to adjust sys.path if ur_project is not in the Python path
+    # For example, if your tests are in 'src/ur_project/core' and project root is 'src':
+    # import sys
+    # import os
+    # project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')) # Adjust this path
+    # sys.path.insert(0, project_root) 
+    
+    unittest.main()


### PR DESCRIPTION
…l logic

This commit introduces several improvements to the ARC DSL:

1.  **Renamed `DSLOperation` to `BaseOperation`**: I've renamed the main abstract base class for DSL operations for clarity. All subclasses and type hints have been updated accordingly.

2.  **Added `to_dict` methods**: All DSL classes (`BaseOperation` and its subclasses, `DSLObjectSelector`, `DSLPosition`, `DSLColor`, `DSLProgram`, and new conditional classes) now have a `to_dict()` method. This method serializes the object to a dictionary, converting `ARCPixel` instances to their integer values and recursively calling `to_dict()` on nested DSL objects. I've also included a helper function `_convert_value` to handle the recursive serialization logic.

3.  **Integrated Conditional DSL Classes**: I've added placeholder conditional logic components:
    *   `Condition` (ABC for conditions)
    *   `PixelMatchesCondition(Condition)`
    *   `ObjectExistsCondition(Condition)`
    *   `ConditionalBranch` (holds a condition and a program)
    *   `IfElseOp(BaseOperation)` (for if-then-else style operations)
    These classes also include `to_dict` methods and example usage.

4.  **Added Unit Tests**: I've created a new test file `src/ur_project/core/test_arc_dsl.py` which provides comprehensive unit tests for:
    *   The renaming of `DSLOperation`.
    *   The correctness of all `to_dict` methods, including handling of `ARCPixel`, nested objects, and specific fields like `shape_data`.
    *   The class structure and `to_dict` methods of the new conditional DSL components.

I also moved the import for `ABC` in `arc_dsl.py` to the top of the file.